### PR TITLE
Update deploy steps to split traffic between versions

### DIFF
--- a/docs/source/topics/deployment.rst
+++ b/docs/source/topics/deployment.rst
@@ -14,7 +14,11 @@ Push all your changes, including the new tag::
 
 Make sure you have the `Google Cloud SDK`_ installed and type this command from the root directory to deploy::
 
-    gcloud app deploy --version 1 --project chirpradio-hrd
+    gcloud app deploy --no-promote --no-stop-previous-version --project=chirpradio-hrd --version=VERSION_NAME
+
+The new version can be tested on a version-specific URL that will be listed in the console output of that command as the "target url".
+
+Traffic can be split between the previous and new version and gradually migrated over for further testing and control: https://cloud.google.com/appengine/docs/standard/python/splitting-traffic
 
 .. _`Google Cloud SDK`: https://cloud.google.com/sdk/
 


### PR DESCRIPTION
Includes the command for deploying a new version without promoting it or stopping the previous version, plus a link to describe how to split traffic from the console UI.