### PR TITLE
Add call to updatePlaylistStorage function

### DIFF
--- a/api/handler.py
+++ b/api/handler.py
@@ -31,6 +31,7 @@ except ImportError:
 
 from playlists.models import (chirp_playlist_key, PlaylistTrack,
                               PlayCountSnapshot)
+from playlists.tasks import _push_notify
 from djdb import pylast
 from common import dbconfig
 
@@ -198,6 +199,7 @@ class CheckLastFMLinks(webapp.RequestHandler):
         track.lastfm_urls_processed = True  # Even on error
         track.save()
         memcache.delete(CurrentPlaylist.cache_key)
+        _push_notify('chirpradio.push.update-playlist-storage')
         self.response.out.write(simplejson.dumps({
             'success': True,
             'links_fetched': links_fetched

--- a/playlists/tasks.py
+++ b/playlists/tasks.py
@@ -99,6 +99,7 @@ def send_track_to_live_site(request):
     log.info('Pushing notifications for track %r' % request.POST['id'])
     success = [_push_notify('chirpradio.push.now-playing'),
                _push_notify('chirpradio.push.tweet-now-playing'),  # this calls a Google Cloud Function
+               _push_notify('chirpradio.push.update-playlist-storage'),  # this calls a Google Cloud Function
                _push_notify('chirpradio.push.recently-played')]
     if all(success):
         return HttpResponse("OK")


### PR DESCRIPTION
# What kind of change does this PR introduce?
Adds a call to a Cloud Function that will save the output of /api/current_playlist to a Cloud Storage bucket.

# What is the current behavior?
Traffic to the https://chirpradio-hrd.appspot.com app is overwhelmingly driven by calls to /api/current_playlist. That endpoint runs at low latency due to smart use of memcache, but it also means that a few instances of the app are running all day long mostly to serve up the same data that only changes every 3-5 minutes. 

# What is the new behavior?
This PR adds a call to [a new Cloud Function](https://github.com/chirpradio/cloud-functions/tree/master/update-playlist-storage) that calls /api/current_playlist and copies the response to a public Cloud Storage bucket. The intent is to update chirpradio.org so it calls the public Cloud Storage URL instead of /api/current_playlist. By my estimation this should allow the AppEngine app to mostly stay within free tier pricing and reduce CHIRP's operating costs by ~95%.