### PR TITLE
Update playlist storage before notifying consumers

### DIFF
--- a/playlists/tasks.py
+++ b/playlists/tasks.py
@@ -97,10 +97,10 @@ playlist_event_listeners = PlaylistEventDispatcher([
 def send_track_to_live_site(request):
     """View for task queue that tells chirpradio.org a new track was entered"""
     log.info('Pushing notifications for track %r' % request.POST['id'])
-    success = [_push_notify('chirpradio.push.now-playing'),
-               _push_notify('chirpradio.push.tweet-now-playing'),  # this calls a Google Cloud Function
-               _push_notify('chirpradio.push.update-playlist-storage'),  # this calls a Google Cloud Function
-               _push_notify('chirpradio.push.recently-played')]
+    success = [_push_notify('chirpradio.push.update-playlist-storage'),  # this calls a Google Cloud Function
+                _push_notify('chirpradio.push.tweet-now-playing'),  # this calls a Google Cloud Function
+                _push_notify('chirpradio.push.now-playing'),                
+                _push_notify('chirpradio.push.recently-played')]
     if all(success):
         return HttpResponse("OK")
     else:


### PR DESCRIPTION
Switches the order of push notifications so the playlist storage is updated first, increasing the likelihood that the calls made to LastFM to load album art finish before API clients request the updated JSON.